### PR TITLE
bugfix: do NOT forward TC ready to TC tracker during TC initialization

### DIFF
--- a/src/main/scala/tagcache.scala
+++ b/src/main/scala/tagcache.scala
@@ -997,6 +997,7 @@ class TCInitiator(id:Int)(implicit p: Parameters) extends TCModule()(p) {
     io.tag_xact.req.valid  := Bool(true)
     io.tag_xact.req.bits.addr := UInt(tgHelper.map1Base) + UInt(id) * UInt(p(CacheBlockBytes)) + rst_cnt * UInt(nTagTransactors * p(CacheBlockBytes))
     io.tag_xact.req.bits.op   := TCTagOp.C
+    io.mem_xact.req.ready  := Bool(false)
     io.mem_xact.resp.valid := Bool(false)
   }
 


### PR DESCRIPTION
If a TC access accidentally occur during the TC initialization process, the processor stuck as the ready signal to the L2 memory tracker is not properly blocked.